### PR TITLE
Fix status inconsistent when kill buffer

### DIFF
--- a/zoom-window.el
+++ b/zoom-window.el
@@ -148,7 +148,8 @@
     (if (and (one-window-p) (not enabled))
         (message "There is only one window!!")
       (if enabled
-          (zoom-window--do-unzoom)
+          (ignore-errors
+            (zoom-window--do-unzoom))
         (zoom-window--save-mode-line-color)
         (zoom-window--do-register-action 'window-configuration-to-register)
         (delete-other-windows)


### PR DESCRIPTION
In zoom-window state, if kill the buffer and turn off zoom-window, (zoom-window--do-register-action 'jump-to-register) will signal a error and quit, (zoom-window--toggle-enabled) will not be call, so zoom-window--enabled stay in t, this will make zoom-window unavalialbe.

Ignore the error will fix this.