### PR TITLE
use `with-demoted-errors` to ignore errors

### DIFF
--- a/zoom-window.el
+++ b/zoom-window.el
@@ -148,7 +148,7 @@
     (if (and (one-window-p) (not enabled))
         (message "There is only one window!!")
       (if enabled
-          (ignore-errors
+          (with-demoted-errors "Warning: %S"
             (zoom-window--do-unzoom))
         (zoom-window--save-mode-line-color)
         (zoom-window--do-register-action 'window-configuration-to-register)


### PR DESCRIPTION
`ignore-errors` is not friendly with debugging, it will not print the
error or allow the error to be debugged when `toggle-debug-on-error` is
active, `with-demoted-errors` just print the error and go on running
when `toggle-debug-on-error` is non active, and will debug the error when
`toggle-debug-on-error` is active.