### PR TITLE
add support for tab-bar mode (#21)

### DIFF
--- a/test/zoom-window-tab-bar-test.el
+++ b/test/zoom-window-tab-bar-test.el
@@ -1,0 +1,106 @@
+;;; zoom-window-tab-bar-test.el --- Tests for tab-bar support -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'ert)
+(require 'tab-bar)
+
+(add-to-list 'load-path
+             (file-name-directory
+              (directory-file-name
+               (file-name-directory (or load-file-name buffer-file-name)))))
+
+(require 'zoom-window)
+
+(defun zoom-window-tab-bar-test--cleanup (orig-mode-line frame)
+  "Restore tab-bar and zoom-window global state using ORIG-MODE-LINE on FRAME."
+  (remove-hook 'tab-bar-tab-post-open-functions #'zoom-window--tab-bar-set-default)
+  (remove-hook 'tab-bar-tab-post-select-functions #'zoom-window--tab-bar-update)
+  (while (> (length (tab-bar-tabs)) 1)
+    (tab-bar-close-tab))
+  (tab-bar-mode -1)
+  (clrhash zoom-window--window-configuration)
+  (setq zoom-window--orig-color nil)
+  (set-face-background 'mode-line orig-mode-line frame)
+  (force-mode-line-update))
+
+(ert-deftest zoom-window-tab-bar-setup-is-idempotent ()
+  "Repeated setup should not register duplicate tab-bar hooks."
+  (skip-unless (require 'tab-bar nil t))
+  (let ((frame (selected-frame))
+        (orig-mode-line (face-background 'mode-line))
+        (zoom-window-use-tab-bar t)
+        (zoom-window-use-elscreen nil)
+        (zoom-window-use-persp nil))
+    (unwind-protect
+        (progn
+          (tab-bar-mode 1)
+          (zoom-window-setup)
+          (zoom-window-setup)
+          (should (= 1 (cl-count #'zoom-window--tab-bar-set-default
+                                 tab-bar-tab-post-open-functions)))
+          (should (= 1 (cl-count #'zoom-window--tab-bar-update
+                                 tab-bar-tab-post-select-functions))))
+      (zoom-window-tab-bar-test--cleanup orig-mode-line frame))))
+
+(ert-deftest zoom-window-tab-bar-keeps-state-per-tab ()
+  "Zoom state should stay isolated to the current tab."
+  (skip-unless (require 'tab-bar nil t))
+  (let ((frame (selected-frame))
+        (orig-mode-line (face-background 'mode-line))
+        (zoom-window-use-tab-bar t)
+        (zoom-window-use-elscreen nil)
+        (zoom-window-use-persp nil))
+    (unwind-protect
+        (progn
+          (tab-bar-mode 1)
+          (zoom-window-setup)
+
+          (delete-other-windows)
+          (switch-to-buffer (get-buffer-create "*zoom-window-tab-1*"))
+          (split-window-right)
+          (other-window 1)
+          (switch-to-buffer (get-buffer-create "*zoom-window-tab-2*"))
+          (other-window -1)
+
+          (zoom-window-zoom)
+          (should (zoom-window--enable-p))
+          (should (zoom-window--tab-bar-current-tab-property
+                   'zoom-window-window-configuration))
+
+          (tab-bar-new-tab)
+          (should-not (zoom-window--enable-p))
+          (should-not (zoom-window--tab-bar-current-tab-property
+                       'zoom-window-window-configuration))
+
+          (split-window-right)
+          (zoom-window-zoom)
+          (should (zoom-window--enable-p))
+          (should (= 1 (length (window-list))))
+          (zoom-window-zoom)
+          (should-not (zoom-window--enable-p))
+          (should (= 2 (length (window-list))))
+
+          (tab-bar-select-tab 1)
+          (should (zoom-window--enable-p))
+          (should (= 1 (length (window-list))))
+
+          (zoom-window-zoom)
+          (should-not (zoom-window--enable-p))
+          (should (= 2 (length (window-list)))))
+      (zoom-window-tab-bar-test--cleanup orig-mode-line frame))))
+
+(ert-deftest zoom-window-without-tab-bar-uses-frame-state ()
+  "Default behavior should remain frame-scoped when tab-bar support is disabled."
+  (let ((zoom-window-use-tab-bar nil)
+        (zoom-window-use-elscreen nil)
+        (zoom-window-use-persp nil))
+    (delete-other-windows)
+    (split-window-right)
+    (zoom-window-zoom)
+    (should (frame-parameter (selected-frame) 'zoom-window-enabled))
+    (should (gethash :zoom-window zoom-window--window-configuration))
+    (zoom-window-zoom)
+    (should-not (frame-parameter (selected-frame) 'zoom-window-enabled))
+    (should-not (gethash :zoom-window zoom-window--window-configuration))))
+
+;;; zoom-window-tab-bar-test.el ends here

--- a/zoom-window.el
+++ b/zoom-window.el
@@ -39,6 +39,7 @@
 (declare-function elscreen-get-conf-list "elscreen")
 (declare-function safe-persp-name "persp-mode")
 (declare-function get-frame-persp "persp-mode")
+(declare-function tab-bar-tabs "tab-bar")
 
 (defgroup zoom-window nil
   "zoom window like tmux"
@@ -51,6 +52,14 @@
 
 (defcustom zoom-window-use-persp nil
   "Non-nil means using persp-mode."
+  :type 'boolean
+  :group 'zoom-window)
+
+(defcustom zoom-window-use-tab-bar nil
+  "Non-nil means keeping zoom state isolated per `tab-bar' tab.
+
+This also works for packages such as `tabspaces' that build on top of
+`tab-bar'.  Call `zoom-window-setup' after enabling this option."
   :type 'boolean
   :group 'zoom-window)
 
@@ -152,6 +161,57 @@ PERSP: the perspective to be killed."
           (delq (assoc persp-name zoom-window-persp-alist)
                 zoom-window-persp-alist))))
 
+(defun zoom-window--tab-bar-current-tab ()
+  "Return the current `tab-bar' tab object."
+  (when (fboundp 'tab-bar-tabs)
+    (cl-find-if (lambda (tab)
+                  (eq (car tab) 'current-tab))
+                (tab-bar-tabs))))
+
+(defun zoom-window--tab-bar-current-tab-property (prop)
+  "Return current `tab-bar' PROP value."
+  (let* ((tab (zoom-window--tab-bar-current-tab))
+         (state (and tab (assoc-default 'zoom-window-state tab))))
+    (when state
+      (assoc-default prop state))))
+
+(defun zoom-window--tab-bar-put-property (prop value &optional tab)
+  "Store VALUE under PROP in TAB.
+When TAB is nil, use the current `tab-bar' tab."
+  (let* ((target (or tab (zoom-window--tab-bar-current-tab)))
+         (state (and target (assoc-default 'zoom-window-state target)))
+         (state-cell (and target (assq 'zoom-window-state target)))
+         (next-state (zoom-window--put-alist prop value state)))
+    (unless target
+      (error "Current tab-bar tab is not available"))
+    (if state-cell
+        (setcdr state-cell next-state)
+      (nconc target (list (cons 'zoom-window-state next-state))))
+    value))
+
+(defun zoom-window--tab-bar-update (&rest _)
+  "Update mode-line face for the currently selected `tab-bar' tab."
+  (let ((color (if (zoom-window--tab-bar-current-tab-property
+                    'zoom-window-is-zoomed)
+                   zoom-window-mode-line-color
+                 (or (zoom-window--tab-bar-current-tab-property
+                      'zoom-window-saved-color)
+                     zoom-window--orig-color))))
+    (set-face-background 'mode-line color (window-frame nil))
+    (force-mode-line-update)))
+
+(defun zoom-window--tab-bar-set-default (&optional tab)
+  "Reset `zoom-window' state for TAB.
+When TAB is nil, reset the current `tab-bar' tab."
+  (let ((target (or tab (zoom-window--tab-bar-current-tab))))
+    (when target
+      (zoom-window--tab-bar-put-property 'zoom-window-is-zoomed nil target)
+      (zoom-window--tab-bar-put-property 'zoom-window-saved-color
+                                         zoom-window--orig-color target)
+      (zoom-window--tab-bar-put-property 'zoom-window-buffers nil target)
+      (zoom-window--tab-bar-put-property 'zoom-window-window-configuration
+                                         nil target))))
+
 ;;;###autoload
 (defun zoom-window-setup ()
   "To work with elscreen or persp-mode."
@@ -173,6 +233,21 @@ PERSP: the perspective to be killed."
               #'zoom-window--persp-before-switch-hook)
     (add-hook 'persp-renamed-functions #'zoom-window--persp-rename-hook)
     (add-hook 'persp-before-kill-functions #'zoom-window--persp-before-kill-hook))
+
+   ;; to work with tab-bar/tabspaces
+   (zoom-window-use-tab-bar
+    (unless (require 'tab-bar nil t)
+      (error "tab-bar is not available in this Emacs"))
+
+    (setq zoom-window--orig-color (face-background 'mode-line))
+
+    (remove-hook 'tab-bar-tab-post-open-functions #'zoom-window--tab-bar-set-default)
+    (remove-hook 'tab-bar-tab-post-select-functions #'zoom-window--tab-bar-update)
+    (add-hook 'tab-bar-tab-post-open-functions #'zoom-window--tab-bar-set-default)
+    (add-hook 'tab-bar-tab-post-select-functions #'zoom-window--tab-bar-update)
+    ;; for first tab
+    (zoom-window--tab-bar-set-default)
+    (zoom-window--tab-bar-update))
 
    ;; do nothing else
    (t nil)))
@@ -204,6 +279,10 @@ PERSP: the perspective to be killed."
                                           property
                                           zoom-window-persp-alist))))
 
+        (zoom-window-use-tab-bar
+         (zoom-window--tab-bar-put-property 'zoom-window-saved-color
+                                            (face-background 'mode-line)))
+
         (t (setq zoom-window--orig-color (face-background 'mode-line)))))
 
 (defun zoom-window--save-buffers ()
@@ -222,6 +301,8 @@ PERSP: the perspective to be killed."
                              'zoom-window-buffers buffers property))
              (setq zoom-window-persp-alist (zoom-window--put-alist
                                             persp-name property zoom-window-persp-alist))))
+          (zoom-window-use-tab-bar
+           (zoom-window--tab-bar-put-property 'zoom-window-buffers buffers))
           (t
            (set-frame-parameter
             (window-frame nil) 'zoom-window-buffers buffers)))))
@@ -234,6 +315,8 @@ PERSP: the perspective to be killed."
          (let* ((persp-name (safe-persp-name (get-frame-persp)))
                 (property (assoc-default persp-name zoom-window-persp-alist)))
            (assoc-default 'zoom-window-buffers property)))
+        (zoom-window-use-tab-bar
+         (zoom-window--tab-bar-current-tab-property 'zoom-window-buffers))
         (t
          (frame-parameter (window-frame nil) 'zoom-window-buffers))))
 
@@ -249,6 +332,11 @@ PERSP: the perspective to be killed."
                        (property (assoc-default persp-name
                                                 zoom-window-persp-alist)))
                   (assoc-default 'zoom-window-saved-color property)))
+
+               (zoom-window-use-tab-bar
+                (or (zoom-window--tab-bar-current-tab-property
+                     'zoom-window-saved-color)
+                    zoom-window--orig-color))
 
                (t zoom-window--orig-color))))
     (set-face-background 'mode-line color (window-frame nil))))
@@ -267,14 +355,22 @@ PERSP: the perspective to be killed."
 
 (defun zoom-window--save-window-configuration ()
   "Not documented."
-  (let ((key (zoom-window--configuration-key))
-        (window-conf (list (current-window-configuration) (point-marker))))
-    (puthash key window-conf zoom-window--window-configuration)))
+  (let ((window-conf (list (current-window-configuration) (point-marker))))
+    (if zoom-window-use-tab-bar
+        (zoom-window--tab-bar-put-property 'zoom-window-window-configuration
+                                           window-conf)
+      (let ((key (zoom-window--configuration-key)))
+        (puthash key window-conf zoom-window--window-configuration)))))
 
 (defun zoom-window--restore-window-configuration ()
   "Not documented."
-  (let* ((key (zoom-window--configuration-key))
-         (window-context (gethash key zoom-window--window-configuration 'not-found)))
+  (let ((window-context
+         (if zoom-window-use-tab-bar
+             (or (zoom-window--tab-bar-current-tab-property
+                  'zoom-window-window-configuration)
+                 'not-found)
+           (let ((key (zoom-window--configuration-key)))
+             (gethash key zoom-window--window-configuration 'not-found)))))
     (when (eq window-context 'not-found)
       (error "window configuration is not found"))
     (let ((window-conf (cl-first window-context))
@@ -282,7 +378,11 @@ PERSP: the perspective to be killed."
       (set-window-configuration window-conf)
       (when (marker-buffer marker)
         (goto-char marker))
-      (remhash key zoom-window--window-configuration))))
+      (if zoom-window-use-tab-bar
+          (zoom-window--tab-bar-put-property 'zoom-window-window-configuration
+                                             nil)
+        (remhash (zoom-window--configuration-key)
+                 zoom-window--window-configuration)))))
 
 (defun zoom-window--toggle-enabled ()
   "Not documented."
@@ -307,6 +407,11 @@ PERSP: the perspective to be killed."
                                     property
                                     zoom-window-persp-alist))))
 
+   (zoom-window-use-tab-bar
+    (let ((value (zoom-window--tab-bar-current-tab-property
+                  'zoom-window-is-zoomed)))
+      (zoom-window--tab-bar-put-property 'zoom-window-is-zoomed (not value))))
+
    (t (let* ((curframe (window-frame nil))
              (status (frame-parameter curframe 'zoom-window-enabled)))
         (set-frame-parameter curframe 'zoom-window-enabled (not status))))))
@@ -321,6 +426,9 @@ PERSP: the perspective to be killed."
     (let* ((persp-name (safe-persp-name (get-frame-persp)))
            (property (assoc-default persp-name zoom-window-persp-alist)))
       (and property (assoc-default 'zoom-window-is-zoomed property))))
+
+   (zoom-window-use-tab-bar
+    (zoom-window--tab-bar-current-tab-property 'zoom-window-is-zoomed))
 
    (t (frame-parameter (window-frame nil) 'zoom-window-enabled))))
 


### PR DESCRIPTION
 This PR adds optional tab-bar/tabspaces-aware zoom state isolation.

   When `zoom-window-use-tab-bar` is non-nil, `zoom-window` stores zoom state per `tab-bar` tab instead of sharing it across the whole frame. This makes zoom/unzoom
 work correctly with `tab-bar`-based workflows, including `tabspaces`, where each tab should keep its own zoomed window state. It should solve the issue #21 